### PR TITLE
Fix bugs from lodash/merge behavior

### DIFF
--- a/client/src/components/QueryUI/QueryUIContext.js
+++ b/client/src/components/QueryUI/QueryUIContext.js
@@ -50,12 +50,13 @@ class QueryUIProvider extends React.Component {
     // because the event will not persist asynchronously
     const checked = e.target.checked;
     this.setState(state => ({
-      ui: merge({}, state.ui, {
+      ui: {
+        ...state.ui,
         filtering: checked,
         filteredGenesValue: '',
         filteredGenes: [],
-      }),
-    }));
+      }
+    }))
   }
 
   handleExample = () => {
@@ -123,11 +124,12 @@ class QueryUIProvider extends React.Component {
     const filteredGenes = this.genesFromSelectedGoTerms(selectedTerms, this.state.goTerms);
 
     this.setState(state => ({
-      ui: merge({}, state.ui, {
+      ui: {
+        ...state.ui,
         selectedTerms,
         filteredGenes,
         filteredGenesValue: filteredGenes.join('\n'),
-      })
+      }
     }))
   }
 


### PR DESCRIPTION
Fix problem where `lodash/merge` will deep merge arrays vs. replace. Therefore, `remove` functions can't use `lodash/merge` and should therefore use a shallow merge strategy instead.